### PR TITLE
Add time-sensitive 'GitHub Skills' activity (issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,6 +77,14 @@ activities = {
     }
 }
 
+# Time-sensitive activity requested in issue #6
+activities["GitHub Skills"] = {
+    "description": "Practical coding and collaboration workshops powered by GitHub; prepares students for GitHub Certifications.",
+    "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+    "max_participants": 25,
+    "participants": []
+}
+
 
 @app.get("/")
 def root():


### PR DESCRIPTION
This quick PR adds the GitHub Skills activity requested in issue #6 so students can register before the announced deadline. It updates the in-memory `activities` dictionary in `src/app.py` with a new entry for "GitHub Skills" (schedule, description, capacity). This is a small, time-sensitive change; follow-up work should migrate activities to a persistent store.